### PR TITLE
fix: persist smartcollection tag to prevent duplicate collections

### DIFF
--- a/Jellyfin.Plugin.SmartCollections/SmartCollectionsManager.cs
+++ b/Jellyfin.Plugin.SmartCollections/SmartCollectionsManager.cs
@@ -455,6 +455,11 @@ namespace Jellyfin.Plugin.SmartCollections
                     IsLocked = true
                 });
                 collection.Tags = new[] { "smartcollection" };
+                await _libraryManager.UpdateItemAsync(
+                    collection,
+                    collection.GetParent(),
+                    ItemUpdateType.MetadataEdit,
+                    CancellationToken.None);
                 isNewCollection = true;
             }
             collection.DisplayOrder = "Default";


### PR DESCRIPTION
After creating a new collection, the `smartcollection` tag was set on the in-memory object but never saved to the database via `UpdateItemAsync`. On subsequent scans, `GetBoxSetByName` queries for BoxSets with the `smartcollection` tag, couldn't find the existing collection, and created a new duplicate every time.

Fix: call `UpdateItemAsync` after setting the tag to persist it to the database.

Closes #25