### PR TITLE
fix: assembly version mismatch and stale manifest targetAbi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       run: dotnet restore Jellyfin.Plugin.SmartCollections.sln
     
     - name: Build
-      run: dotnet build Jellyfin.Plugin.SmartCollections.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=false
+      run: dotnet build Jellyfin.Plugin.SmartCollections.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=false /p:Version=${{ steps.get_version.outputs.VERSION }} /p:AssemblyVersion=${{ steps.get_version.outputs.VERSION }} /p:FileVersion=${{ steps.get_version.outputs.VERSION }}
     
     - name: Get version from tag
       id: get_version
@@ -82,3 +82,14 @@ jobs:
         prerelease: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Update manifest on main
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git fetch origin main
+        git checkout main
+        cp manifest.json manifest.json
+        git add manifest.json
+        git commit -m "chore: update manifest for ${{ steps.get_version.outputs.VERSION }}" || true
+        git push origin main

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
       {
         "version": "0.0.0.12",
         "changelog": "- See the full changelog at [GitHub](https://github.com/johnpc/jellyfin-plugin-smart-collections/releases/tag/0.0.0.12)\n",
-        "targetAbi": "10.9.9.0",
+        "targetAbi": "10.11.0.0",
         "sourceUrl": "https://github.com/johnpc/jellyfin-plugin-smart-collections/releases/download/0.0.0.12/jellyfin-plugin-smartcollections-0.0.0.12.zip",
         "checksum": "e29805838c6f96711529af7276899d84",
         "timestamp": "2025-12-08T03:10:35Z"


### PR DESCRIPTION
Three fixes:

1. **DLL version stuck at 0.0.0.8**: The release workflow never passed the tag version to `dotnet build`, so `AssemblyVersion`/`FileVersion` in the DLL were always `0.0.0.8` (hardcoded in .csproj). Now passes `/p:Version`, `/p:AssemblyVersion`, and `/p:FileVersion` from the git tag.

2. **Manifest targetAbi wrong**: The manifest on main said `10.9.9.0` but the plugin is built against Jellyfin 10.11.0. Updated to `10.11.0.0`.

3. **Manifest goes stale**: Added a step to auto-commit the updated manifest back to main after each release so the repo URL always serves the latest version.

Fixes #22